### PR TITLE
Allow grid-container to transform with image

### DIFF
--- a/dnd-mapper.css
+++ b/dnd-mapper.css
@@ -5,6 +5,7 @@
 #grid-container {
     margin: 0 auto;
     overflow: hidden;
+    transform: rotate(0deg);
 }
 
 #grid-container svg {

--- a/index.js
+++ b/index.js
@@ -25,6 +25,7 @@ function RotateImage(rot) {
         angle -= 90;
     }
     image.style.transform = 'rotate(' + angle + 'deg)';
+    $('#grid-container').css("transform", 'rotate(' + angle + 'deg)')
 };
 
 /* Grid Creation */


### PR DESCRIPTION
This transforms the grid-container with the same rotation as the image.
This should solve issue #2 
But this might be changed when issue #3 is fixed.